### PR TITLE
feat(docker): update to work with modern-mean pre-reqs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN mkdir -p /home/modern-mean/logs
 # disable NPM color output to keep logs cleaner
 RUN npm config set color false
 
-# Install Mean.JS Prerequisites
+# Install Modern-MEAN Prerequisites
 RUN npm install -g gulpjs/gulp-cli#4.0
 RUN npm install -g bower
 
-# Install Mean.JS packages
+# Install Modern-MEAN packages
 ADD package.json /home/modern-mean/package.json
 RUN npm install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.12
+FROM node:5.10
 
 # Install gem sass for  grunt-contrib-sass
 RUN apt-get update -qq && apt-get install -y build-essential
@@ -6,12 +6,16 @@ RUN apt-get install -y ruby
 RUN gem install sass
 
 WORKDIR /home/modern-mean
+RUN mkdir -p /home/modern-mean/logs
 
-# Install Modern-MEAN Prerequisites
-RUN npm install -g gulp
+# disable NPM color output to keep logs cleaner
+RUN npm config set color false
+
+# Install Mean.JS Prerequisites
+RUN npm install -g gulpjs/gulp-cli#4.0
 RUN npm install -g bower
 
-# Install Modern-MEAN packages
+# Install Mean.JS packages
 ADD package.json /home/modern-mean/package.json
 RUN npm install
 
@@ -23,10 +27,8 @@ RUN bower install --config.interactive=false --allow-root
 # Make everything available for start
 ADD . /home/modern-mean
 
-# Set development environment as default
-ENV NODE_ENV development
-
-# Port 3000 for server
+# Port 8080 for server
 # Port 35729 for livereload
-EXPOSE 3000 35729
-CMD ["grunt"]
+EXPOSE 8080 35729
+CMD ["gulp","prod"]
+


### PR DESCRIPTION
A number of changes were made to make the docker file work with the modern-mean project setup. Most issues were introduced from the original fork from meanjs
